### PR TITLE
feat(order): pdf generate

### DIFF
--- a/app/Http/Controllers/Order/OrderPdfController.php
+++ b/app/Http/Controllers/Order/OrderPdfController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers\Order;
 
 use App\Http\Controllers\Controller;
 use App\Models\Order;
-use Dompdf\Dompdf;
+use App\Services\OrderPDFService;
 use Illuminate\Http\Request;
 
 class OrderPdfController extends Controller
@@ -14,21 +14,7 @@ class OrderPdfController extends Controller
     public function download(Request $request, int $id)
     {
         $order = Order::findOrFail($id);
-        $data['order'] = $order;
-        //Debug
-        //return view('order.print', $data);
-        $html = view('order.print', $data)->render();
 
-        $dompdf = new Dompdf();
-        $dompdf->loadHtml($html);
-
-        // Opcional: configurar opciones de Dompdf (margenes, tamaño de papel, etc)
-        $dompdf->setPaper('A4', 'portrait');
-
-        // Render PDF
-        $dompdf->render();
-
-        // Download PDF
-        return $dompdf->stream('order_'.$order->id.'.pdf');
+        return response((new OrderPDFService())->getPDF($order));
     }
 }

--- a/app/Services/OrderPDFService.php
+++ b/app/Services/OrderPDFService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Cezpdf;
+
+class OrderPDFService
+{
+    public function getPDF($order): void
+    {
+        $pdf = new Cezpdf('A4', 'portrait');
+
+        $pdf->ezSetMargins(80, 300, 80, 80);
+
+        $mainFont = 'Times-Roman';
+        $pdf->selectFont($mainFont);
+
+        $pdf->openHere('Fit');
+
+        $pdf->ezText(__('PEDIDO').' número: '.$order->id, 18);
+
+        $pdf->ezSetY(600);
+
+        $pdf->rectangle(80, 620, 200, 100);
+        $pdf->rectangle(300, 620, 200, 100);
+
+        $cols = [
+            'sku' => 'SKU',
+            'name' => __('Product'),
+            'price' => __('Price'),
+            'tax' => __('Tax'),
+            'quantity' => __('Quantity'),
+        ];
+
+        $items = $order->items->map(function ($item) {
+            return [
+                'sku' => $item['product']['sku'],
+                'name' => $item['product']['name'],
+                'price' => $item['product']['price'],
+                'tax' => $item['product']['tax'],
+                'quantity' => $item['quantity'],
+            ];
+        })->toArray();
+
+        $pdf->ezTable($items, $cols);
+
+        $pdf->ezStream(['compress' => 0]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "psr/simple-cache": "^2.0",
         "qoraiche/laravel-mail-editor": "^4.0",
         "ramsey/uuid": "^4.2",
+        "rospdf/pdf-php": "^0.12.65",
         "sentry/sentry-laravel": "^3.2",
         "shopify/shopify-api": "^4.2",
         "spatie/icalendar-generator": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61cbfa8ebae7412d3acd88b575501ad7",
+    "content-hash": "8a090538afa4071f61f879a7615fb3f4",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -6050,6 +6050,80 @@
                 }
             ],
             "time": "2022-02-07T20:28:03+00:00"
+        },
+        {
+            "name": "rospdf/pdf-php",
+            "version": "0.12.65",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rospdf/pdf-php.git",
+                "reference": "d9d468977260538ca999cbf561cae690d8330c4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rospdf/pdf-php/zipball/d9d468977260538ca999cbf561cae690d8330c4b",
+                "reference": "d9d468977260538ca999cbf561cae690d8330c4b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-experimental": "0.13.x-dev",
+                    "dev-master": "0.12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Cpdf.php",
+                    "src/Cezpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ole Koeckemann",
+                    "email": "ole.k@web.de",
+                    "role": "Project Head / Developer"
+                },
+                {
+                    "name": "Lars Olesen",
+                    "email": "lars@intraface.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sune Jensen",
+                    "email": "sj@sunet.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Wayne Munro",
+                    "email": "pdf@ros.co.nz",
+                    "role": "Founder / Inactive"
+                }
+            ],
+            "description": "The R&OS Pdf class supports the creation of PDF documents without any adiditional modules or extensions.",
+            "homepage": "https://github.com/rospdf/pdf-php",
+            "support": {
+                "issues": "https://github.com/rospdf/pdf-php/issues",
+                "source": "https://github.com/rospdf/pdf-php/tree/0.12.65"
+            },
+            "time": "2022-11-16T17:07:58+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",


### PR DESCRIPTION
In this case we have not used html or css. We have generated the PDF file using a package that although it is not as attractive as css but adjusts to the millimeter creating a template with headers and footers, tables, ....

For the example we have put a sufficiently large bottom margin so that the page break is carried out and so that you can see the result of the products table.